### PR TITLE
Ignore *.Zone:Identifier files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore *.Zone:Identifier files when user copy a file
+# from the host to WSL VM.
+Zone:Identifier


### PR DESCRIPTION
There is no use of it. Better ignore them.

Signed-off-by: Tuan Anh <tuan73176@gmail.com>
